### PR TITLE
Package gerrit-rest-java-client into this plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,31 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.urswolfer.gerrit.client.rest</groupId>
+                                    <artifactId>gerrit-rest-java-client</artifactId>
+                                    <version>0.8.8</version>
+                                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                                    <includes>**/*</includes>
+                                    <excludes>**/RevisionApi*.class</excludes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
@@ -72,7 +97,7 @@
                     <target>1.7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
-              </plugin>
+            </plugin>
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
@@ -106,6 +131,7 @@
             <groupId>com.urswolfer.gerrit.client.rest</groupId>
             <artifactId>gerrit-rest-java-client</artifactId>
             <version>0.8.8</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
We override RevisionApi classes in gerrit-rest-java-client to include
the verifystatus endpoint.  When run using `java -jar jenkins.war` the
jenkins plugin classpath puts the gerrit-rest-java-client ahead of the
RevisionApi class that's in this plugin which results in a
NoSuchMethodError[1].  To make jenkins use this version of RevisionApi
we repackage gerrit-rest-java-client into this plugin excluding the
RevisionApi classes.

[1] java.lang.NoSuchMethodError: com.google.gerrit.extensions.api.changes
.RevisionApi.verifyStatus()Lcom/google/gerrit/extensions/api/changes/VerifyStatusApi;
at org.jenkinsci.plugins.verifystatus.VerificationsPublisher.perform(VerificationsPublisher.java:174)
at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:785)
at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:726)
at hudson.model.Build$BuildExecution.cleanUp(Build.java:195)
at hudson.model.Run.execute(Run.java:1788)
at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
at hudson.model.ResourceController.execute(ResourceController.java:98)
at hudson.model.Executor.run(Executor.java:408)